### PR TITLE
Changed the link conditioner to be optional

### DIFF
--- a/examples/channels.rs
+++ b/examples/channels.rs
@@ -67,7 +67,7 @@ impl Plugin for BallsExample {
             .add_system(ball_control_system.system())
         }
         .add_resource(args)
-        .add_plugin(NetworkingPlugin)
+        .add_plugin(NetworkingPlugin::default())
         .add_startup_system(network_setup.system())
         .add_resource(NetworkReader::default())
         .add_system(handle_packets.system());

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -33,7 +33,7 @@ fn main() {
         )))
         .add_plugins(MinimalPlugins)
         // The NetworkingPlugin
-        .add_plugin(NetworkingPlugin)
+        .add_plugin(NetworkingPlugin::default())
         // Our networking
         .add_resource(parse_args())
         .add_startup_system(startup.system())


### PR DESCRIPTION
There's no reason to have a link conditioner by default (it's even a bad idea) so I made it optional so that it can still be used to testing but it doesn't interfere with normal operation