### PR TITLE
Make NetworkResource constructor public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ unsafe impl Send for NetworkResource {}
 unsafe impl Sync for NetworkResource {}
 
 impl NetworkResource {
-    fn new(task_pool: TaskPool, link_conditioner: Option<LinkConditionerConfig>) -> Self {
+    pub fn new(task_pool: TaskPool, link_conditioner: Option<LinkConditionerConfig>) -> Self {
         let runtime = TaskPoolRuntime::new(task_pool.clone());
         let packet_pool =
             MuxPacketPool::new(BufferPacketPool::new(SimpleBufferPool(MAX_PACKET_LEN)));


### PR DESCRIPTION
I'd like to have an ability to initialize the networking plugin myself, registering all resources and systems manually.

My use-case is that my systems that read network events have a custom scheduler, so I don't want to flush the events every frame (otherwise I miss events from previous frames).

If we make the constructor public, this will let users control how they want to initialize the networking. For example, users may also want to add systems into different stages.

Thank you!