### PR TITLE
Allow users to drop connections, handle channel disconnects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,8 @@ console_log = "0.2"
 name = "channels"
 path = "examples/channels.rs"
 required-features = ["bevy/default"]
+
+[patch.crates-io]
+# TODO: watch https://github.com/naia-rs/naia-socket/pull/29.
+naia-client-socket = { git = "https://github.com/mvlabat/naia-socket.git" }
+naia-server-socket = { git = "https://github.com/mvlabat/naia-socket.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ use-webrtc = [
 ]
 
 [dependencies]
-bevy_app = "0.4"
-bevy_ecs = "0.4"
-bevy_tasks = "0.4"
+bevy_app = "0.5"
+bevy_ecs = "0.5"
+bevy_tasks = "0.5"
 turbulence = "0.3"
 naia-client-socket = { version = "0.5", features = ["multithread"] }
 bytes = "1.0"
@@ -45,7 +45,7 @@ futures-timer = "3.0"
 naia-server-socket = "0.4"
 
 [dev-dependencies]
-bevy = { version = "0.4", default-features = false }
+bevy = { version = "0.5", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 simple_logger = "1"
 rand = { version = "0.7.3", features = ["wasm-bindgen"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub struct NetworkResource {
     #[cfg(not(target_arch = "wasm32"))]
     listeners: Vec<ServerListener>,
     #[cfg(not(target_arch = "wasm32"))]
-    server_channels: Arc<RwLock<HashMap<SocketAddr, Sender<Packet>>>>,
+    server_channels: Arc<RwLock<HashMap<SocketAddr, Sender<Result<Packet, NetworkError>>>>>,
 
     runtime: TaskPoolRuntime,
     packet_pool: MuxPacketPool<BufferPacketPool<SimpleBufferPool>>,
@@ -99,12 +99,14 @@ pub enum NetworkEvent {
     Connected(ConnectionHandle),
     Disconnected(ConnectionHandle),
     Packet(ConnectionHandle, Packet),
-    Error(NetworkError),
+    Error(ConnectionHandle, NetworkError),
 }
 
+#[derive(Debug)]
 pub enum NetworkError {
     TurbulenceChannelError(IncomingTrySendError<MultiplexedPacket>),
-    IoError(Box<dyn Error + Send>),
+    IoError(Box<dyn Error + Sync + Send>),
+    Disconnected,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -165,37 +167,57 @@ impl NetworkResource {
                             message
                         );
 
-                        match server_channels.write() {
-                            Ok(mut server_channels) => {
-                                if !server_channels.contains_key(&address) {
-                                    let (packet_tx, packet_rx): (Sender<Packet>, Receiver<Packet>) =
-                                        unbounded();
-                                    pending_connections.lock().unwrap().push(Box::new(
-                                        transport::ServerConnection::new(
-                                            task_pool.clone(),
-                                            packet_rx,
-                                            server_socket.get_sender(),
-                                            address,
-                                        ),
-                                    ));
-                                    server_channels.insert(address, packet_tx);
-                                }
+                        let needs_new_channel = match server_channels
+                            .read()
+                            .expect("server channels lock is poisoned")
+                            .get(&address)
+                            .map(|channel| {
+                                channel.send(Ok(Packet::copy_from_slice(packet.payload())))
+                            }) {
+                            Some(Ok(())) => false,
+                            Some(Err(error)) => {
+                                log::error!("Server Send Error: {}", error);
+                                // If we can't send to a channel, it's disconnected.
+                                // We need to re-create the channel and re-try sending the message.
+                                true
                             }
-                            Err(err) => {
-                                log::error!("Error locking server channels: {}", err);
-                            }
+                            // This is a new connection, so we need to create a channel.
+                            None => true,
+                        };
+
+                        if !needs_new_channel {
+                            continue;
                         }
 
-                        match server_channels
-                            .read()
-                            .unwrap()
-                            .get(&address)
-                            .unwrap()
-                            .send(Packet::copy_from_slice(packet.payload()))
-                        {
-                            Ok(()) => {}
+                        // We try to do a write lock only in case when a channel doesn't exist or
+                        // has to be re-created. Trying to acquire a channel even for new
+                        // connections is kind of a positive prediction to avoid doing a write
+                        // lock.
+                        let mut server_channels = server_channels
+                            .write()
+                            .expect("server channels lock is poisoned");
+                        let (packet_tx, packet_rx): (
+                            Sender<Result<Packet, NetworkError>>,
+                            Receiver<Result<Packet, NetworkError>>,
+                        ) = unbounded();
+                        match packet_tx.send(Ok(Packet::copy_from_slice(packet.payload()))) {
+                            Ok(()) => {
+                                // It makes sense to store the channel only if it's healthy.
+                                pending_connections.lock().unwrap().push(Box::new(
+                                    transport::ServerConnection::new(
+                                        task_pool.clone(),
+                                        packet_rx,
+                                        server_socket.get_sender(),
+                                        address,
+                                    ),
+                                ));
+                                server_channels.insert(address, packet_tx);
+                            }
                             Err(error) => {
-                                log::error!("Server Send Error: {}", error);
+                                // This branch is unlikely to get called the second time (after
+                                // re-creating a channel), but if for some strange reason it does,
+                                // we'll just lose the message this time.
+                                log::error!("Server Send Error (retry): {}", error);
                             }
                         }
                     }
@@ -239,7 +261,7 @@ impl NetworkResource {
         &mut self,
         handle: ConnectionHandle,
         payload: Packet,
-    ) -> Result<(), Box<dyn Error + Send>> {
+    ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         match self.connections.get_mut(&handle) {
             Some(connection) => connection.send(payload),
             None => Err(Box::new(std::io::Error::new(
@@ -349,6 +371,7 @@ pub fn receive_packets(
                             Err(err) => {
                                 log::error!("Channel Incoming Error: {}", err);
                                 network_events.send(NetworkEvent::Error(
+                                    *handle,
                                     NetworkError::TurbulenceChannelError(err),
                                 ));
                             }
@@ -359,8 +382,8 @@ pub fn receive_packets(
                     }
                 }
                 Err(err) => {
-                    log::error!("Receive Error: {}", err);
-                    network_events.send(NetworkEvent::Error(NetworkError::IoError(err)));
+                    log::error!("Receive Error: {:?}", err);
+                    network_events.send(NetworkEvent::Error(*handle, err));
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ unsafe impl Send for NetworkResource {}
 unsafe impl Sync for NetworkResource {}
 
 impl NetworkResource {
-    fn new(task_pool: TaskPool, link_conditioner: Option<LinkConditionerConfig>) -> Self {
+    pub fn new(task_pool: TaskPool, link_conditioner: Option<LinkConditionerConfig>) -> Self {
         let runtime = TaskPoolRuntime::new(task_pool.clone());
         let packet_pool =
             MuxPacketPool::new(BufferPacketPool::new(SimpleBufferPool(MAX_PACKET_LEN)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,13 +48,13 @@ pub struct NetworkingPlugin {
 impl Plugin for NetworkingPlugin {
     fn build(&self, app: &mut AppBuilder) {
         let task_pool = app
-            .resources()
-            .get::<IoTaskPool>()
+            .world()
+            .get_resource::<IoTaskPool>()
             .expect("IoTaskPool resource not found")
             .0
             .clone();
 
-        app.add_resource(NetworkResource::new(
+        app.insert_resource(NetworkResource::new(
             task_pool,
             self.link_conditioner.clone(),
         ))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use turbulence::{
     buffer::BufferPacketPool,
     message_channels::ChannelMessage,
     packet::{Packet as PoolPacket, PacketPool, MAX_PACKET_LEN},
-    packet_multiplexer::MuxPacketPool,
+    packet_multiplexer::{IncomingTrySendError, MuxPacketPool},
 };
 pub use turbulence::{
     message_channels::{MessageChannelMode, MessageChannelSettings},
@@ -35,7 +35,10 @@ pub use turbulence::{
 
 mod channels;
 mod transport;
-use self::channels::{SimpleBufferPool, TaskPoolRuntime};
+use self::{
+    channels::{SimpleBufferPool, TaskPoolRuntime},
+    transport::MultiplexedPacket,
+};
 pub use transport::{Connection, ConnectionChannelsBuilder, Packet};
 
 pub type ConnectionHandle = u32;
@@ -85,7 +88,8 @@ pub struct NetworkResource {
 #[cfg(not(target_arch = "wasm32"))]
 #[allow(dead_code)] // FIXME: remove this struct?
 struct ServerListener {
-    receiver_task: bevy_tasks::Task<()>, // needed to keep receiver_task alive
+    receiver_task: bevy_tasks::Task<()>,
+    // needed to keep receiver_task alive
     sender: ServerSender,
     socket_address: SocketAddr,
 }
@@ -95,11 +99,17 @@ pub enum NetworkEvent {
     Connected(ConnectionHandle),
     Disconnected(ConnectionHandle),
     Packet(ConnectionHandle, Packet),
-    // Error(NetworkError),
+    Error(NetworkError),
+}
+
+pub enum NetworkError {
+    TurbulenceChannelError(IncomingTrySendError<MultiplexedPacket>),
+    IoError(Box<dyn Error + Send>),
 }
 
 #[cfg(target_arch = "wasm32")]
 unsafe impl Send for NetworkResource {}
+
 #[cfg(target_arch = "wasm32")]
 unsafe impl Sync for NetworkResource {}
 
@@ -338,7 +348,9 @@ pub fn receive_packets(
                             }
                             Err(err) => {
                                 log::error!("Channel Incoming Error: {}", err);
-                                // FIXME:error_events.send(error);
+                                network_events.send(NetworkEvent::Error(
+                                    NetworkError::TurbulenceChannelError(err),
+                                ));
                             }
                         }
                     } else {
@@ -348,7 +360,7 @@ pub fn receive_packets(
                 }
                 Err(err) => {
                     log::error!("Receive Error: {}", err);
-                    // FIXME:error_events.send(error);
+                    network_events.send(NetworkEvent::Error(NetworkError::IoError(err)));
                 }
             }
         }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -22,7 +22,10 @@ use futures_lite::future::block_on;
 
 use futures_lite::StreamExt;
 
-use super::channels::{SimpleBufferPool, TaskPoolRuntime};
+use super::{
+    channels::{SimpleBufferPool, TaskPoolRuntime},
+    NetworkError,
+};
 
 pub type Packet = Bytes;
 pub type MultiplexedPacket = MuxPacket<<BufferPacketPool<SimpleBufferPool> as PacketPool>::Packet>;
@@ -32,9 +35,9 @@ pub type ConnectionChannelsBuilder =
 pub trait Connection: Send + Sync {
     fn remote_address(&self) -> Option<SocketAddr>;
 
-    fn send(&mut self, payload: Packet) -> Result<(), Box<dyn Error + Send>>;
+    fn send(&mut self, payload: Packet) -> Result<(), Box<dyn Error + Send + Sync>>;
 
-    fn receive(&mut self) -> Option<Result<Packet, Box<dyn Error + Send>>>;
+    fn receive(&mut self) -> Option<Result<Packet, NetworkError>>;
 
     fn build_channels(
         &mut self,
@@ -52,7 +55,7 @@ pub trait Connection: Send + Sync {
 pub struct ServerConnection {
     task_pool: TaskPool,
 
-    packet_rx: crossbeam_channel::Receiver<Packet>,
+    packet_rx: crossbeam_channel::Receiver<Result<Packet, NetworkError>>,
     sender: Option<ServerSender>,
     client_address: SocketAddr,
 
@@ -66,7 +69,7 @@ pub struct ServerConnection {
 impl ServerConnection {
     pub fn new(
         task_pool: TaskPool,
-        packet_rx: crossbeam_channel::Receiver<Packet>,
+        packet_rx: crossbeam_channel::Receiver<Result<Packet, NetworkError>>,
         sender: ServerSender,
         client_address: SocketAddr,
     ) -> Self {
@@ -88,7 +91,7 @@ impl Connection for ServerConnection {
         Some(self.client_address)
     }
 
-    fn send(&mut self, payload: Packet) -> Result<(), Box<dyn Error + Send>> {
+    fn send(&mut self, payload: Packet) -> Result<(), Box<dyn Error + Send + Sync>> {
         block_on(
             self.sender
                 .as_mut()
@@ -97,12 +100,14 @@ impl Connection for ServerConnection {
         )
     }
 
-    fn receive(&mut self) -> Option<Result<Packet, Box<dyn Error + Send>>> {
+    fn receive(&mut self) -> Option<Result<Packet, NetworkError>> {
         match self.packet_rx.try_recv() {
-            Ok(payload) => Some(Ok(payload)),
+            Ok(payload) => Some(payload),
             Err(error) => match error {
                 crossbeam_channel::TryRecvError::Empty => None,
-                err => Some(Err(Box::new(err))),
+                crossbeam_channel::TryRecvError::Disconnected => {
+                    Some(Err(NetworkError::Disconnected))
+                }
             },
         }
     }
@@ -179,17 +184,17 @@ impl Connection for ClientConnection {
         None
     }
 
-    fn send(&mut self, payload: Packet) -> Result<(), Box<dyn Error + Send>> {
+    fn send(&mut self, payload: Packet) -> Result<(), Box<dyn Error + Send + Sync>> {
         self.sender
             .as_mut()
             .unwrap()
             .send(ClientPacket::new(payload.to_vec()))
     }
 
-    fn receive(&mut self) -> Option<Result<Packet, Box<dyn Error + Send>>> {
+    fn receive(&mut self) -> Option<Result<Packet, NetworkError>> {
         match self.socket.receive() {
             Ok(event) => event.map(|event| Ok(Packet::copy_from_slice(event.payload()))),
-            Err(err) => Some(Err(Box::new(err))),
+            Err(err) => Some(Err(NetworkError::IoError(Box::new(err)))),
         }
     }
 
@@ -240,5 +245,6 @@ impl Connection for ClientConnection {
 
 #[cfg(target_arch = "wasm32")]
 unsafe impl Send for ClientConnection {}
+
 #[cfg(target_arch = "wasm32")]
 unsafe impl Sync for ClientConnection {}

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -25,7 +25,7 @@ use futures_lite::StreamExt;
 use super::channels::{SimpleBufferPool, TaskPoolRuntime};
 
 pub type Packet = Bytes;
-type MultiplexedPacket = MuxPacket<<BufferPacketPool<SimpleBufferPool> as PacketPool>::Packet>;
+pub type MultiplexedPacket = MuxPacket<<BufferPacketPool<SimpleBufferPool> as PacketPool>::Packet>;
 pub type ConnectionChannelsBuilder =
     MessageChannelsBuilder<TaskPoolRuntime, MuxPacketPool<BufferPacketPool<SimpleBufferPool>>>;
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -58,6 +58,7 @@ pub struct ServerConnection {
 
     channels: Option<MessageChannels>,
     channels_rx: Option<IncomingMultiplexedPackets<MultiplexedPacket>>,
+    #[allow(dead_code)]
     channels_task: Option<Task<()>>,
 }
 
@@ -150,6 +151,7 @@ pub struct ClientConnection {
 
     channels: Option<MessageChannels>,
     channels_rx: Option<IncomingMultiplexedPackets<MultiplexedPacket>>,
+    #[allow(dead_code)]
     #[cfg(not(target_arch = "wasm32"))]
     channels_task: Option<Task<()>>,
 }
@@ -186,10 +188,7 @@ impl Connection for ClientConnection {
 
     fn receive(&mut self) -> Option<Result<Packet, Box<dyn Error + Send>>> {
         match self.socket.receive() {
-            Ok(event) => match event {
-                Some(packet) => Some(Ok(Packet::copy_from_slice(packet.payload()))),
-                None => None,
-            },
+            Ok(event) => event.map(|event| Ok(Packet::copy_from_slice(event.payload()))),
             Err(err) => Some(Err(Box::new(err))),
         }
     }


### PR DESCRIPTION
This PR is an attempt to implement #17.

I'll rebase it after #18 gets merged (currently, I upgraded to Bevy 0.5 myself, but I didn't touch the examples).

This PR also depends on my fork of naia, which adds `Sync` trait to socket errors (see https://github.com/naia-rs/naia-socket/pull/29), to make it possible to pass naia errors via `NetworkEvent::Error` to Bevy events. Probably, this change shouldn't be a part of this PR, as it isn't essential for the issue it tries to fix. I just had a compulsion to remove a couple of `FIXME` in the code. :)

The main change though is error handling of sending messages to server channels. Currently, if a user removes a connection from the public `NetworkResource::connections` field manually, this case isn't properly handled: a server still tries to push messages to a disconnected channel.

Detecting that a channel has been disconnected allows us to remove that channel. If a server decides to send a new message to a client, a channel will be re-created, which also partially resolves this problem: #6. I realize that the scope of that issue is broader (according to the discussion), but this solution might become a legit workaround for the initial problem that was brought up:
> if you quit a client application and then open a new one on the same port it can't reconnect to the server again until you restart the server 😬

This PR is by no means well-tested (so far it just covers my own use-cases I tested in my pet project) and finished, but I'd be happy to receive some early feedback.

TODOs:
- [ ] I haven't checked this flow on the client side yet. Probably, we need a similar approach to handle manual disconnects there.