### PR TITLE
Add packet stats to transport

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -2,7 +2,7 @@
 use bevy_tasks::Task;
 use bevy_tasks::TaskPool;
 use bytes::Bytes;
-use std::{error::Error, net::SocketAddr};
+use std::{error::Error, net::SocketAddr, sync::{Arc, RwLock}};
 
 use naia_client_socket::{
     ClientSocketTrait, MessageSender as ClientSender, Packet as ClientPacket,
@@ -32,6 +32,24 @@ pub type MultiplexedPacket = MuxPacket<<BufferPacketPool<SimpleBufferPool> as Pa
 pub type ConnectionChannelsBuilder =
     MessageChannelsBuilder<TaskPoolRuntime, MuxPacketPool<BufferPacketPool<SimpleBufferPool>>>;
 
+#[derive(Default, Debug, Clone)]
+pub struct PacketStats {
+    pub packets_tx: usize,
+    pub packets_rx: usize,
+    pub bytes_tx: usize,
+    pub bytes_rx: usize,
+}
+impl PacketStats {
+    fn add_tx(&mut self, num_bytes: usize) {
+        self.packets_tx += 1;
+        self.bytes_tx += num_bytes;
+    }
+    fn add_rx(&mut self, num_bytes: usize) {
+        self.packets_rx += 1;
+        self.bytes_rx += num_bytes;
+    }
+}
+
 pub trait Connection: Send + Sync {
     fn remote_address(&self) -> Option<SocketAddr>;
 
@@ -49,6 +67,8 @@ pub trait Connection: Send + Sync {
     fn channels(&mut self) -> Option<&mut MessageChannels>;
 
     fn channels_rx(&mut self) -> Option<&mut IncomingMultiplexedPackets<MultiplexedPacket>>;
+
+    fn stats(&self) -> PacketStats;
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -58,6 +78,7 @@ pub struct ServerConnection {
     packet_rx: crossbeam_channel::Receiver<Result<Packet, NetworkError>>,
     sender: Option<ServerSender>,
     client_address: SocketAddr,
+    stats: Arc<RwLock<PacketStats>>,
 
     channels: Option<MessageChannels>,
     channels_rx: Option<IncomingMultiplexedPackets<MultiplexedPacket>>,
@@ -78,6 +99,7 @@ impl ServerConnection {
             packet_rx,
             sender: Some(sender),
             client_address,
+            stats: Arc::new(RwLock::new(PacketStats::default())),
             channels: None,
             channels_rx: None,
             channels_task: None,
@@ -91,7 +113,12 @@ impl Connection for ServerConnection {
         Some(self.client_address)
     }
 
+    fn stats(&self) -> PacketStats {
+        self.stats.read().expect("stats lock poisoned").clone()
+    }
+
     fn send(&mut self, payload: Packet) -> Result<(), Box<dyn Error + Sync + Send>> {
+        self.stats.write().expect("stats lock poisoned").add_tx(payload.len());
         block_on(
             self.sender
                 .as_mut()
@@ -102,7 +129,13 @@ impl Connection for ServerConnection {
 
     fn receive(&mut self) -> Option<Result<Packet, NetworkError>> {
         match self.packet_rx.try_recv() {
-            Ok(payload) => Some(payload),
+            Ok(payload) => match payload {
+                Ok(packet) => {
+                    self.stats.write().expect("stats lock poisoned").add_rx(packet.len());
+                    Some(Ok(packet))
+                },
+                Err(err) => Some(Err(err))
+            },
             Err(error) => match error {
                 crossbeam_channel::TryRecvError::Empty => None,
                 crossbeam_channel::TryRecvError::Disconnected => {
@@ -128,9 +161,11 @@ impl Connection for ServerConnection {
 
         let mut sender = self.sender.take().unwrap();
         let client_address = self.client_address;
+        let stats = self.stats.clone();
         self.channels_task = Some(self.task_pool.spawn(async move {
             loop {
                 let packet = channels_tx.next().await.unwrap();
+                stats.write().expect("stats lock poisoned").add_tx(packet.len());
                 sender
                     .send(ServerPacket::new(client_address, (*packet).into()))
                     .await
@@ -153,6 +188,7 @@ pub struct ClientConnection {
 
     socket: Box<dyn ClientSocketTrait>,
     sender: Option<ClientSender>,
+    stats: Arc<RwLock<PacketStats>>,
 
     channels: Option<MessageChannels>,
     channels_rx: Option<IncomingMultiplexedPackets<MultiplexedPacket>>,
@@ -170,6 +206,7 @@ impl ClientConnection {
             task_pool,
             socket,
             sender: Some(sender),
+            stats: Arc::new(RwLock::new(PacketStats::default())),
             channels: None,
             channels_rx: None,
             #[cfg(not(target_arch = "wasm32"))]
@@ -183,7 +220,12 @@ impl Connection for ClientConnection {
         None
     }
 
+    fn stats(&self) -> PacketStats {
+        self.stats.read().expect("stats lock poisoned").clone()
+    }
+
     fn send(&mut self, payload: Packet) -> Result<(), Box<dyn Error + Sync + Send>> {
+        self.stats.write().expect("stats lock poisoned").add_tx(payload.len());
         self.sender
             .as_mut()
             .unwrap()
@@ -192,7 +234,10 @@ impl Connection for ClientConnection {
 
     fn receive(&mut self) -> Option<Result<Packet, NetworkError>> {
         match self.socket.receive() {
-            Ok(event) => event.map(|packet| Ok(Packet::copy_from_slice(packet.payload()))),
+            Ok(event) => event.map(|packet| {
+                self.stats.write().expect("stats lock poisoned").add_rx(packet.payload().len());
+                Ok(Packet::copy_from_slice(packet.payload()))
+            }),
             Err(err) => Some(Err(NetworkError::IoError(Box::new(err)))),
         }
     }
@@ -212,11 +257,13 @@ impl Connection for ClientConnection {
         self.channels_rx = Some(channels_rx);
 
         let mut sender = self.sender.take().unwrap();
+        let stats = self.stats.clone();
         #[allow(unused_variables)]
         let channels_task = self.task_pool.spawn(async move {
             loop {
                 match channels_tx.next().await {
                     Some(packet) => {
+                        stats.write().expect("stats lock poisoned").add_tx(packet.len());
                         sender.send(ClientPacket::new((*packet).into())).unwrap();
                     }
                     None => {


### PR DESCRIPTION
How do you feel about adding something like this to track packets and bytes sent and received?

I am using it locally to better understand how turbulence is batching up packets.

Usage example:

```rust
fn stats_logger(net: Res<NetworkResource>) {
    for (handle, connection) in net.connections.iter() {
        log::info!("h:{} {:?}", handle, connection.stats());
    }
} 
```
logs:
```
INFO h:0 PacketStats { packets_tx: 12, packets_rx: 12, bytes_tx: 492, bytes_rx: 492 }
```