### PR TITLE
Disconnect cleanups, idle timeouts, auto heartbeats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ use-webrtc = [
 
 [dependencies]
 bevy_app = "0.5"
+bevy_core = "0.5"
 bevy_ecs = "0.5"
 bevy_tasks = "0.5"
 turbulence = "0.3"
@@ -45,6 +46,7 @@ futures-timer = "3.0"
 naia-server-socket = "0.5"
 
 [dev-dependencies]
+clap = "2.33.3"
 bevy = { version = "0.5", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 simple_logger = "1"

--- a/examples/channels.rs
+++ b/examples/channels.rs
@@ -12,14 +12,14 @@ use bevy::{
 };
 use bevy_networking_turbulence::{
     ConnectionChannelsBuilder, MessageChannelMode, MessageChannelSettings, NetworkEvent,
-    NetworkResource, NetworkingPlugin, ReliableChannelSettings, MessageFlushingStrategy,
+    NetworkResource, NetworkingPlugin, ReliableChannelSettings,
 };
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, net::SocketAddr, time::Duration};
 
 mod utils;
-use utils::*;
+use utils::{SimpleArgs as Args, parse_simple_args};
 
 const SERVER_PORT: u16 = 14192;
 const BOARD_WIDTH: u32 = 1000;
@@ -44,7 +44,7 @@ struct BallsExample;
 
 impl Plugin for BallsExample {
     fn build(&self, app: &mut AppBuilder) {
-        let args = parse_args();
+        let args = parse_simple_args();
         if args.is_server {
             // Server
             app.insert_resource(ScheduleRunnerSettings::run_loop(Duration::from_secs_f64(

--- a/examples/idle_timeout.readme.md
+++ b/examples/idle_timeout.readme.md
@@ -1,0 +1,127 @@
+# Notes on idle_timeout example
+
+* `Idle timeout` means if no packets received for the specified duration, we drop the connection.
+* `Heartbeat` is a packet sent automatically, and discarded by the remote peer, if we have otherwise not sent anything for the specified duration. Heartbeat packets exist to prevent the other peer from idle-timeout dropping you.
+* By default, there are no idle timeouts or heartbeats.
+* Heartbeat packets are standard UDP packets (not turbulence messages) and as such may not arrive.
+
+
+## Idle timeout, to drop inactive connections
+
+Run the server with a 3 second idle-drop-timeout:
+
+`env RUST_LOG=info cargo run --example idle_timeout -- --server --pongs 2 --idle-drop-timeout 3000`
+
+```
+2021-06-24 11:56:40,864 INFO  [idle_timeout] IdleTimeoutArgs { is_server: true, pings: 0, pongs: 2, idle_timeout_ms: Some(3000), auto_heartbeat_ms: None }
+2021-06-24 11:56:40,867 INFO  [idle_timeout] Starting server
+... run the client ...
+2021-06-24 11:56:46,063 INFO  [idle_timeout] Other event: Connected(0)
+2021-06-24 11:56:46,063 INFO  [idle_timeout] Got packet on [0]: PING
+2021-06-24 11:56:46,064 INFO  [idle_timeout] Sent PONG
+2021-06-24 11:56:47,072 INFO  [idle_timeout] Got packet on [0]: PING
+2021-06-24 11:56:47,072 INFO  [idle_timeout] Sent PONG
+2021-06-24 11:56:50,388 WARN  [bevy_networking_turbulence] Idle disconnect for h:0
+2021-06-24 11:56:50,405 INFO  [idle_timeout] Other event: Error(0, MissedHeartbeat)
+2021-06-24 11:56:50,406 INFO  [idle_timeout] Other event: Disconnected(0)
+```
+
+Run a client:
+
+`env RUST_LOG=info cargo run --example idle_timeout -- --client --pings 3`
+
+```
+2021-06-24 11:56:45,040 INFO  [idle_timeout] IdleTimeoutArgs { is_server: false, pings: 2, pongs: 0, idle_timeout_ms: None, auto_heartbeat_ms: None }
+2021-06-24 11:56:45,043 INFO  [idle_timeout] Starting client
+2021-06-24 11:56:45,063 INFO  [idle_timeout] Other event: Connected(0)
+2021-06-24 11:56:46,089 INFO  [idle_timeout] Got packet on [0]: PONG
+2021-06-24 11:56:47,054 INFO  [idle_timeout] (No more pings left to send)
+2021-06-24 11:56:47,095 INFO  [idle_timeout] Got packet on [0]: PONG
+```
+
+Note that 3 seconds after the last PING was received by the server, it drops the connection. The client has no idea this has happened, because dropping a connection doesn't attempt to signal the remote peer.
+
+If you restart the client now, after the server has dropped it, the client will be assigned a new `ConnectionHandle` and proceed as normal. 
+
+## Making the client detect dropped connections
+
+Set the same `--idle-drop-timeout` value on the client, and it will also get a `NetworkError::MissedHeartbeat` followed immediately by a `NetworkError:Disconnected`.
+
+## Using heartbeats to keep connections open
+
+If your higher level protocol doesn't guarantee messages will be sent frequently enough, you can enable auto heartbeats. Since they can be lost (plain udp packets), setting the heartbeat timeout to less than a half of the idle-drop-timeout gives you a second chance if the first heartbeat packet is lost.
+
+Nothing is logged at the `INFO` level for heartbeats, but if you run a client like this at `DEBUG`:
+
+`env RUST_LOG=info cargo run --example idle_timeout -- --client --pings 3 --heartbeat-interval 1000`
+
+```
+2021-06-24 12:11:45,315 INFO  [idle_timeout] IdleTimeoutArgs { is_server: false, pings: 3, pongs: 0, idle_timeout_ms: None, auto_heartbeat_ms: Some(1000) }
+2021-06-24 12:11:45,318 INFO  [idle_timeout] Starting client
+2021-06-24 12:11:45,319 INFO  [idle_timeout] Other event: Connected(0)
+2021-06-24 12:11:45,830 DEBUG [bevy_networking_turbulence] millis since last rx: 511 tx: 511
+2021-06-24 12:11:46,321 DEBUG [bevy_networking_turbulence] millis since last rx: 1002 tx: 0
+2021-06-24 12:11:46,357 DEBUG [bevy_networking_turbulence] Received on [0] 4 RAW: PONG
+2021-06-24 12:11:46,357 DEBUG [bevy_networking_turbulence] Processing as packet
+2021-06-24 12:11:46,358 INFO  [idle_timeout] Got packet on [0]: PONG
+2021-06-24 12:11:46,823 DEBUG [bevy_networking_turbulence] millis since last rx: 465 tx: 502
+2021-06-24 12:11:47,334 DEBUG [bevy_networking_turbulence] millis since last rx: 976 tx: 0
+2021-06-24 12:11:47,352 DEBUG [bevy_networking_turbulence] Received on [0] 4 RAW: PONG
+2021-06-24 12:11:47,352 DEBUG [bevy_networking_turbulence] Processing as packet
+2021-06-24 12:11:47,352 INFO  [idle_timeout] Got packet on [0]: PONG
+2021-06-24 12:11:47,832 DEBUG [bevy_networking_turbulence] millis since last rx: 480 tx: 498
+2021-06-24 12:11:48,335 INFO  [idle_timeout] (No more pings left to send)
+2021-06-24 12:11:48,335 DEBUG [bevy_networking_turbulence] millis since last rx: 983 tx: 0
+2021-06-24 12:11:48,354 DEBUG [bevy_networking_turbulence] Received on [0] 4 RAW: PONG
+2021-06-24 12:11:48,354 DEBUG [bevy_networking_turbulence] Processing as packet
+2021-06-24 12:11:48,355 INFO  [idle_timeout] Got packet on [0]: PONG
+2021-06-24 12:11:48,829 DEBUG [bevy_networking_turbulence] millis since last rx: 474 tx: 493
+2021-06-24 12:11:49,333 DEBUG [bevy_networking_turbulence] millis since last rx: 978 tx: 998
+2021-06-24 12:11:49,828 DEBUG [bevy_networking_turbulence] millis since last rx: 1473 tx: 1493
+2021-06-24 12:11:49,828 DEBUG [bevy_networking_turbulence] Sending hearbeat packet on h:0
+2021-06-24 12:11:50,331 DEBUG [bevy_networking_turbulence] millis since last rx: 1976 tx: 502
+2021-06-24 12:11:50,833 DEBUG [bevy_networking_turbulence] millis since last rx: 2478 tx: 1005
+2021-06-24 12:11:50,833 DEBUG [bevy_networking_turbulence] Sending hearbeat packet on h:0
+2021-06-24 12:11:51,329 DEBUG [bevy_networking_turbulence] millis since last rx: 2974 tx: 495
+2021-06-24 12:11:51,824 DEBUG [bevy_networking_turbulence] millis since last rx: 3469 tx: 990
+2021-06-24 12:11:52,337 DEBUG [bevy_networking_turbulence] millis since last rx: 3982 tx: 1503
+2021-06-24 12:11:52,337 DEBUG [bevy_networking_turbulence] Sending hearbeat packet on h:0
+2021-06-24 12:11:52,832 DEBUG [bevy_networking_turbulence] millis since last rx: 4477 tx: 495
+2021-06-24 12:11:53,323 DEBUG [bevy_networking_turbulence] millis since last rx: 4968 tx: 986
+2021-06-24 12:11:53,831 DEBUG [bevy_networking_turbulence] millis since last rx: 5476 tx: 1494
+2021-06-24 12:11:53,831 DEBUG [bevy_networking_turbulence] Sending hearbeat packet on h:0
+2021-06-24 12:11:54,323 DEBUG [bevy_networking_turbulence] millis since last rx: 5968 tx: 492
+2021-06-24 12:11:54,833 DEBUG [bevy_networking_turbulence] millis since last rx: 6478 tx: 1001
+2021-06-24 12:11:54,833 DEBUG [bevy_networking_turbulence] Sending hearbeat packet on h:0
+2021-06-24 12:11:55,336 DEBUG [bevy_networking_turbulence] millis since last rx: 6981 tx: 503
+2021-06-24 12:11:55,828 DEBUG [bevy_networking_turbulence] millis since last rx: 7473 tx: 994
+2021-06-24 12:11:56,331 DEBUG [bevy_networking_turbulence] millis since last rx: 7976 tx: 1497
+2021-06-24 12:11:56,331 DEBUG [bevy_networking_turbulence] Sending hearbeat packet on h:0
+2021-06-24 12:11:56,832 DEBUG [bevy_networking_turbulence] millis since last rx: 8477 tx: 500
+2021-06-24 12:11:57,338 DEBUG [bevy_networking_turbulence] millis since last rx: 8983 tx: 1006
+2021-06-24 12:11:57,338 DEBUG [bevy_networking_turbulence] Sending hearbeat packet on h:0
+2021-06-24 12:11:57,826 DEBUG [bevy_networking_turbulence] millis since last rx: 9471 tx: 487
+2021-06-24 12:11:58,324 DEBUG [bevy_networking_turbulence] millis since last rx: 9969 tx: 985
+2021-06-24 12:11:58,835 DEBUG [bevy_networking_turbulence] millis since last rx: 10479 tx: 1495
+2021-06-24 12:11:58,835 DEBUG [bevy_networking_turbulence] Sending hearbeat packet on h:0
+2021-06-24 12:11:59,322 DEBUG [bevy_networking_turbulence] millis since last rx: 10966 tx: 486
+2021-06-24 12:11:59,822 DEBUG [bevy_networking_turbulence] millis since last rx: 11467 tx: 987
+```
+
+Note the following things:
+
+* The server doesn't drop the connection, due to heartbeat packets the client sends.
+* After the 3 ping/pong exchange, the time since last rx keeps increasing. This is because the server does not have heartbeats enabled, so isn't sending anything to the client.
+* The last tx time is as much as 1500ms in some cases, even though we specified 1000ms for heartbeats. This is because the bevy system that checks for idle connections and sends heartbeats runs on a fixed timestep, defaulting to 0.5 seconds. This can be configured in the `NetworkingPlugin` like so:
+
+```rust
+pub struct NetworkingPlugin {
+    /// FixedTimestep for the `heartbeats_and_timeouts` system which checks for idle connections
+    /// and sends heartbeats. Does not need to be every frame.
+    ///
+    /// The `heartbeats_and_timeouts` system is only added if `idle_timeout_ms` or `auto_heartbeat_ms` are specified.
+    ///
+    /// Default if None: 0.5 secs
+    pub heartbeats_and_timeouts_timestep_in_seconds: Option<f64>,
+}
+```

--- a/examples/message_coalescing.rs
+++ b/examples/message_coalescing.rs
@@ -15,7 +15,7 @@ use bevy_networking_turbulence::{
 use std::{net::SocketAddr, time::Duration};
 
 mod utils;
-use utils::*;
+use utils::{MessageCoalescingArgs as Args, parse_message_coalescing_args};
 
 const SERVER_PORT: u16 = 14191;
 const NUM_PINGS: usize = 100;
@@ -45,7 +45,7 @@ fn main() {
         }
     }
 
-    let args = parse_args();
+    let args = parse_message_coalescing_args();
     let mut net_plugin = NetworkingPlugin::default();
     if args.manual_flush {
         net_plugin.message_flushing_strategy = MessageFlushingStrategy::Never;
@@ -72,7 +72,7 @@ fn main() {
         .add_system(handle_messages.system())
         .add_system(ttl_system.system())
         ;
-    if parse_args().manual_flush {
+    if parse_message_coalescing_args().manual_flush {
         app.add_system_to_stage(CoreStage::PostUpdate, flush_channels.system());
     }
     app.run();

--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -67,7 +67,7 @@ pub fn parse_message_coalescing_args() -> MessageCoalescingArgs {
 
 #[allow(dead_code)]
 pub fn parse_idle_timeout_args() -> IdleTimeoutArgs {
-    let matches = ClapApp::new("")
+    let matches = ClapApp::new(exe_name())
         .about("Idle timeout example")
         .args(server_or_client_args().as_slice())
         .args(pings_pongs_args().as_slice())

--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -1,40 +1,164 @@
-pub struct Args {
+// Arg parser for the examples.
+// 
+// each example gets a different Args struct, which it adds as a bevy resource
+
+use clap::{Arg, App as ClapApp, value_t_or_exit};
+
+#[derive(Debug)]
+pub struct SimpleArgs {
     pub is_server: bool,
-    pub manual_flush: bool,
 }
 
-pub fn parse_args() -> Args {
+#[derive(Debug)]
+pub struct MessageCoalescingArgs {
+    pub is_server: bool,
+    pub pings: usize,
+    pub pongs: usize,
+    pub manual_flush: bool,
+    pub auto_flush: bool,
+}
+
+#[derive(Debug)]
+pub struct IdleTimeoutArgs {
+    pub is_server: bool,
+    pub pings: usize,
+    pub pongs: usize,
+    pub idle_timeout_ms: Option<usize>,
+    pub auto_heartbeat_ms: Option<usize>,
+}
+
+#[allow(dead_code)]
+pub fn parse_simple_args() -> SimpleArgs {
+    let matches = ClapApp::new("")
+        .about("Simple example just sends some packets")
+        .args(server_or_client_args().as_slice())
+        .get_matches();
+    SimpleArgs {
+        is_server: matches.is_present("server")
+    }
+}
+
+#[allow(dead_code)]
+pub fn parse_message_coalescing_args() -> MessageCoalescingArgs {
+    let matches = ClapApp::new("")
+        .about("Message coalescing example")
+        .args(server_or_client_args().as_slice())
+        .args(flushing_strategy_args().as_slice())
+        .args(pings_pongs_args().as_slice())
+        .get_matches();
+    MessageCoalescingArgs {
+        is_server: matches.is_present("server"),
+        pings: value_t_or_exit!(matches, "pings", usize),
+        pongs: value_t_or_exit!(matches, "pongs", usize),
+        manual_flush: matches.is_present("manual-flush"),
+        auto_flush: matches.is_present("auto-flush"),
+    }
+}
+
+#[allow(dead_code)]
+pub fn parse_idle_timeout_args() -> IdleTimeoutArgs {
+    let matches = ClapApp::new("")
+        .about("Idle timeout example")
+        .args(server_or_client_args().as_slice())
+        .args(pings_pongs_args().as_slice())
+        .args(timeout_args().as_slice())
+        .get_matches();
+    let idle_timeout_ms = if matches.occurrences_of("idle-drop-timeout") == 1 {
+        Some(value_t_or_exit!(matches, "idle-drop-timeout", usize))
+    } else {
+        None
+    };
+    let auto_heartbeat_ms = if matches.occurrences_of("heartbeat-interval") == 1 {
+        Some(value_t_or_exit!(matches, "heartbeat-interval", usize))
+    } else {
+        None
+    };
+    IdleTimeoutArgs {
+        is_server: matches.is_present("server"),
+        pings: value_t_or_exit!(matches, "pings", usize),
+        pongs: value_t_or_exit!(matches, "pongs", usize),
+        idle_timeout_ms,
+        auto_heartbeat_ms,
+    }
+}
+
+fn server_or_client_args<'a>() -> Vec<Arg<'a, 'a>> {
     cfg_if::cfg_if! {
         if #[cfg(target_arch = "wasm32")] {
-            let is_server = false;
-            let manual_flush = false;
+            // will default to client, unless server specified.
+            // wasm32 builds can't be a server.
+            vec![]
         } else {
-            let args: Vec<String> = std::env::args().collect();
-
-            if args.len() < 2 {
-                panic!("Need to select to run as either a server (--server) or a client (--client), optionally with a second arg of either --auto-flush or --manual-flush");
-            }
-
-            let connection_type = &args[1];
-
-            let is_server = match connection_type.as_str() {
-                "--server" | "-s" => true,
-                "--client" | "-c" => false,
-                _ => panic!("Need to select to run as either a server (--server) or a client (--client)."),
-            };
-
-            let manual_flush = if args.len() == 3 {
-                let flushing = &args[2];
-                match flushing.as_str() {
-                    "--auto-flush" => false,
-                    "--manual-flush" => true,
-                    _ => false,
-                }
-            } else {
-                false
-            };
+            vec![
+                Arg::with_name("server")
+                .help("Listen as a server")
+                .long("server")
+                .required_unless("client")
+                .conflicts_with("client")
+                .takes_value(false)
+                ,
+                Arg::with_name("client")
+                .help("Connect as a client")
+                .long("client")
+                .required_unless("server")
+                .conflicts_with("server")
+                .takes_value(false)
+            ]
         }
     }
+}
 
-    Args { is_server, manual_flush }
+#[allow(dead_code)]
+fn timeout_args<'a>() -> Vec<Arg<'a, 'a>> {
+    vec![
+        Arg::with_name("idle-drop-timeout")
+        .help("Idle timeout (ms) after which to drop inactive connections")
+        .long("idle-drop-timeout")
+        .default_value("3000")
+        .takes_value(true)
+        .required(false)
+        ,
+        Arg::with_name("heartbeat-interval")
+        .help("Interval (ms) after which to send a heartbeat packet, if we've been silent this long")
+        .long("heartbeat-interval")
+        .default_value("1000")
+        .takes_value(true)
+        .required(false)
+    ]   
+}
+
+#[allow(dead_code)]
+fn flushing_strategy_args<'a>() -> Vec<Arg<'a, 'a>> {
+    vec![
+        Arg::with_name("auto-flush")
+        .help("Flush after every send")
+        .long("auto-flush")
+        .required_unless("manual-flush")
+        .conflicts_with("manual-flush")
+        .takes_value(false)
+        ,
+        Arg::with_name("manual-flush")
+        .help("No automatic flushing, you must add a flushing system")
+        .long("manual-flush")
+        .required_unless("auto-flush")
+        .conflicts_with("auto-flush")
+        .takes_value(false)
+    ]
+}
+
+#[allow(dead_code)]
+fn pings_pongs_args<'a>() -> Vec<Arg<'a, 'a>> {
+    vec![
+        Arg::with_name("pings")
+        .long("pings")
+        .default_value("0")
+        .help("Number of pings to send, once connected")
+        .takes_value(true)
+        ,
+        Arg::with_name("pongs")
+        .long("pongs")
+        .default_value("0")
+        .help("Number of pongs available to send as replies to pings")
+        .takes_value(true)
+    ]
 }

--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -27,9 +27,19 @@ pub struct IdleTimeoutArgs {
     pub auto_heartbeat_ms: Option<usize>,
 }
 
+fn exe_name() -> String {
+    match std::env::current_exe() {
+        Ok(pathbuf) => match pathbuf.file_name() {
+            Some(name) => name.to_string_lossy().into(),
+            None => String::new()
+        },
+        Err(_) => String::new()
+    }
+}
+
 #[allow(dead_code)]
 pub fn parse_simple_args() -> SimpleArgs {
-    let matches = ClapApp::new(std::env::current_exe().file_name().to_string_lossy())
+    let matches = ClapApp::new(exe_name())
         .about("Simple example just sends some packets")
         .args(server_or_client_args().as_slice())
         .get_matches();

--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -50,7 +50,7 @@ pub fn parse_simple_args() -> SimpleArgs {
 
 #[allow(dead_code)]
 pub fn parse_message_coalescing_args() -> MessageCoalescingArgs {
-    let matches = ClapApp::new("")
+    let matches = ClapApp::new(exe_name())
         .about("Message coalescing example")
         .args(server_or_client_args().as_slice())
         .args(flushing_strategy_args().as_slice())

--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -29,7 +29,7 @@ pub struct IdleTimeoutArgs {
 
 #[allow(dead_code)]
 pub fn parse_simple_args() -> SimpleArgs {
-    let matches = ClapApp::new("")
+    let matches = ClapApp::new(std::env::current_exe().file_name().to_string_lossy())
         .about("Simple example just sends some packets")
         .args(server_or_client_args().as_slice())
         .get_matches();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,7 +467,8 @@ pub fn heartbeats_and_timeouts(mut net: ResMut<NetworkResource>, mut network_eve
     }
     for handle in needs_hb_handles {
         log::debug!("Sending hearbeat packet on h:{}", handle);
-        net.send(handle, Packet::from_static(transport::HEARTBEAT_PACKET)).unwrap();   
+        // heartbeat packets are empty
+        net.send(handle, Packet::new()).unwrap();
     }
     for handle in silent_handles {
         log::warn!("Idle disconnect for h:{}", handle);
@@ -504,7 +505,8 @@ pub fn receive_packets(
         while let Some(result) = connection.receive() {
             match result {
                 Ok(packet) => {
-                    if packet == transport::HEARTBEAT_PACKET {
+                    // heartbeat packets are empty
+                    if packet.len() == 0 {
                         log::debug!("Received heartbeat packet");
                         // discard without sending a NetworkEvent
                         continue;

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -33,6 +33,8 @@ pub type MultiplexedPacket = MuxPacket<<BufferPacketPool<SimpleBufferPool> as Pa
 pub type ConnectionChannelsBuilder =
     MessageChannelsBuilder<TaskPoolRuntime, MuxPacketPool<BufferPacketPool<SimpleBufferPool>>>;
 
+pub const HEARTBEAT_PACKET: &[u8] = b"BNT:HEARTBEAT";
+
 #[derive(Debug, Clone)]
 pub struct PacketStats {
     pub packets_tx: usize,
@@ -115,6 +117,7 @@ pub struct ServerConnection {
 
     channels: Option<MessageChannels>,
     channels_rx: Option<IncomingMultiplexedPackets<MultiplexedPacket>>,
+    #[allow(dead_code)]
     #[cfg(not(target_arch = "wasm32"))]
     channels_task: Option<Task<()>>,
 }
@@ -230,6 +233,7 @@ pub struct ClientConnection {
 
     channels: Option<MessageChannels>,
     channels_rx: Option<IncomingMultiplexedPackets<MultiplexedPacket>>,
+    #[allow(dead_code)]
     #[cfg(not(target_arch = "wasm32"))]
     channels_task: Option<Task<()>>,
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -115,6 +115,9 @@ pub struct ServerConnection {
 
     channels: Option<MessageChannels>,
     channels_rx: Option<IncomingMultiplexedPackets<MultiplexedPacket>>,
+    // channels_task is used to keep spawned Tasks in-scope so they are not dropped.
+    // we set it, but never read from it, which the compiler warns about.
+    // so we use allow(dead_code), even though it's needed for reference keeping.
     #[allow(dead_code)]
     #[cfg(not(target_arch = "wasm32"))]
     channels_task: Option<Task<()>>,
@@ -231,6 +234,9 @@ pub struct ClientConnection {
 
     channels: Option<MessageChannels>,
     channels_rx: Option<IncomingMultiplexedPackets<MultiplexedPacket>>,
+    // channels_task is used to keep spawned Tasks in-scope so they are not dropped.
+    // we set it, but never read from it, which the compiler warns about.
+    // so we use allow(dead_code), even though it's needed for reference keeping.
     #[allow(dead_code)]
     #[cfg(not(target_arch = "wasm32"))]
     channels_task: Option<Task<()>>,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -33,7 +33,6 @@ pub type MultiplexedPacket = MuxPacket<<BufferPacketPool<SimpleBufferPool> as Pa
 pub type ConnectionChannelsBuilder =
     MessageChannelsBuilder<TaskPoolRuntime, MuxPacketPool<BufferPacketPool<SimpleBufferPool>>>;
 
-pub const HEARTBEAT_PACKET: &[u8] = b"BNT:HEARTBEAT";
 
 #[derive(Debug, Clone)]
 pub struct PacketStats {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -33,7 +33,6 @@ pub type MultiplexedPacket = MuxPacket<<BufferPacketPool<SimpleBufferPool> as Pa
 pub type ConnectionChannelsBuilder =
     MessageChannelsBuilder<TaskPoolRuntime, MuxPacketPool<BufferPacketPool<SimpleBufferPool>>>;
 
-
 #[derive(Debug, Clone)]
 pub struct PacketStats {
     pub packets_tx: usize,


### PR DESCRIPTION
* Added `NetworkResource.disconnect(handle)` which cleans up internal structures.
* Added `NetworkingPlugin.idle_timeout_ms` which, if set, will drop connections if no packets received for this long
* Added `NetworkingPlugin.auto_heartbeat_ms` which, if set, will send a heartbeat packet as needed. Heartbeat packets are not propagated to user-provided bevy systems. They just exist to be received and dropped, to update the idle timeout and keep us from being dropped.
* Added `idle_timeout` example and readme.
* Revamped argparser with a dev-dependency on clap.

The heartbeats and idle timeouts are checked in a bevy system on a fixed timestep much less frequently than per-tick, since that seemed wasteful.

### When is a new ConnectionHandle assigned?

#### When a client times out
If you stop a client, wait for the server to drop and cleanup the connection after `idle_timeout_ms`, then restart the client, it will connect with a new `ConnectionHandle`.

#### When you restart a client quickly without a timeout
If you restart a client quickly, it will reconnect with the same `ConnectionHandle`. This behaviour is unchanged, but it feels like a bug. I think it happens because we identify clients by `SocketAddr`, ie a combo of IP+port. Typically as a client, you'd let the operating system's ephemeral port system assign you a local port, sometimes by specifying a port of 0 (eg: `src_addr = "127.0.0.1:0"`). However, `naia` uses a [linear search for available ports](https://github.com/naia-rs/naia-socket/blob/master/shared/src/find_available_port.rs) so I presume it is reselecting the same port when you quickly restart a client. IMO this would be better left for the OS to pick, unless there is a good reason for this method i'm unaware of.

#### Higher-level solution
Another way to handle this is at the protocol level, where we exchange a random session token as part of a handshake. Probably out of scope for this library though?



Related issues: #6 and #17