### PR TITLE
Clippy lints and no more #![allow] in src/

### DIFF
--- a/examples/idle_timeout.rs
+++ b/examples/idle_timeout.rs
@@ -19,9 +19,11 @@ fn main() {
     let args = parse_idle_timeout_args();
     info!("{:?}", args);
 
-    let mut net_plugin = NetworkingPlugin::default();
-    net_plugin.idle_timeout_ms = args.idle_timeout_ms;
-    net_plugin.auto_heartbeat_ms = args.auto_heartbeat_ms;
+    let net_plugin = NetworkingPlugin {
+        idle_timeout_ms: args.idle_timeout_ms,
+        auto_heartbeat_ms: args.auto_heartbeat_ms,
+        ..Default::default()
+    };
 
     let ppc = PingPongCounter {
         ping_reservoir: args.pings,

--- a/examples/message_coalescing.rs
+++ b/examples/message_coalescing.rs
@@ -27,7 +27,7 @@ struct PingPongCounter {
     pongs_seen: usize,
 }
 
-type TTL = Option<f64>;
+type Ttl = Option<f64>;
 
 type Ticks = usize;
 
@@ -45,7 +45,7 @@ fn main() {
             1.0 / 60.0,
         )))
         .insert_resource::<Ticks>(0)
-        .insert_resource::<TTL>(None)
+        .insert_resource::<Ttl>(None)
         .insert_resource(PingPongCounter::default())
         .add_plugins(MinimalPlugins)
         .add_plugin(LogPlugin)
@@ -126,7 +126,7 @@ fn startup(mut net: ResMut<NetworkResource>, args: Res<Args>) {
 }
 
 fn ttl_system(
-    mut ttl: ResMut<TTL>,
+    mut ttl: ResMut<Ttl>,
     mut exit: EventWriter<AppExit>,
     time: Res<Time>,
     net: Res<NetworkResource>,
@@ -154,7 +154,6 @@ fn ttl_system(
                 }
                 info!("Exiting.");
                 exit.send(AppExit);
-                return;
             } else {
                 *ttl = Some(new_secs);
             }
@@ -166,7 +165,7 @@ fn send_messages(
     mut net: ResMut<NetworkResource>,
     mut ppc: ResMut<PingPongCounter>,
     args: Res<Args>,
-    mut ttl: ResMut<TTL>,
+    mut ttl: ResMut<Ttl>,
     ticks: Res<Ticks>,
 ) {
     if args.is_server {
@@ -191,7 +190,7 @@ fn send_messages(
 fn handle_messages(
     mut net: ResMut<NetworkResource>,
     mut ppc: ResMut<PingPongCounter>,
-    mut ttl: ResMut<TTL>,
+    mut ttl: ResMut<Ttl>,
     ticks: Res<Ticks>,
 ) {
     let mut to_send = Vec::new();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -53,11 +53,9 @@ fn startup(mut net: ResMut<NetworkResource>, args: Res<Args>) {
 }
 
 fn send_packets(mut net: ResMut<NetworkResource>, time: Res<Time>, args: Res<Args>) {
-    if !args.is_server {
-        if (time.seconds_since_startup() * 60.) as i64 % 60 == 0 {
-            info!("PING");
-            net.broadcast(Packet::from("PING"));
-        }
+    if !args.is_server && (time.seconds_since_startup() * 60.) as i64 % 60 == 0 {
+        info!("PING");
+        net.broadcast(Packet::from("PING"));
     }
 }
 fn handle_packets(
@@ -66,23 +64,20 @@ fn handle_packets(
     mut reader: EventReader<NetworkEvent>,
 ) {
     for event in reader.iter() {
-        match event {
-            NetworkEvent::Packet(handle, packet) => {
-                let message = String::from_utf8_lossy(packet);
-                info!("Got packet on [{}]: {}", handle, message);
-                if message == "PING" {
-                    let message = format!("PONG @ {}", time.seconds_since_startup());
-                    match net.send(*handle, Packet::from(message)) {
-                        Ok(()) => {
-                            info!("Sent PONG");
-                        }
-                        Err(error) => {
-                            info!("PONG send error: {}", error);
-                        }
+        if let NetworkEvent::Packet(handle, packet) = event {
+            let message = String::from_utf8_lossy(packet);
+            info!("Got packet on [{}]: {}", handle, message);
+            if message == "PING" {
+                let message = format!("PONG @ {}", time.seconds_since_startup());
+                match net.send(*handle, Packet::from(message)) {
+                    Ok(()) => {
+                        info!("Sent PONG");
+                    }
+                    Err(error) => {
+                        info!("PONG send error: {}", error);
                     }
                 }
             }
-            _ => {}
         }
     }
 }


### PR DESCRIPTION
 Hi, it's me again. This is a PR to improve the code with clippy lints (with the help of rust-analyzer). I've also removed the allow attributes. These were used to not drop some tasks. The trick to avoid that is to use the [detach() method](https://docs.rs/bevy/0.6.0/bevy/tasks/struct.Task.html#method.detach). I've run the examples and they work as intended. I fixed the src/channel.rs file however there are some pinning in it and I'm not really used to that. Please watch out for potential mistakes.