### PR TITLE
update naia-socket deps to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,8 @@ use-webrtc = [
 [dependencies]
 bevy = { version = "0.6", default-features = false }
 turbulence = "0.3"
-naia-client-socket = { version = "0.6", features = ["multithread"] }
+naia-client-socket = ">=0.7.4"
+naia-socket-shared = ">=0.7.4"
 bytes = "1.1"
 futures-lite = "1.12"
 crossbeam-channel = "0.5"
@@ -37,9 +38,10 @@ cfg-if = "1.0"
 instant = "0.1"
 futures = "0.3"
 futures-timer = "3.0"
+url = "2.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-naia-server-socket = "0.5"
+naia-server-socket = ">=0.7.4"
 
 [dev-dependencies]
 clap = "2.34.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ cfg-if = "1.0"
 instant = "0.1"
 futures = "0.3"
 futures-timer = "3.0"
-url = "2.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 naia-server-socket = ">=0.7.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ use-webrtc = [
 [dependencies]
 bevy = { version = "0.6", default-features = false }
 turbulence = "0.3"
-naia-client-socket = ">=0.7.4"
-naia-socket-shared = ">=0.7.4"
+naia-client-socket = "0.8"
+naia-socket-shared = "0.8"
 bytes = "1.1"
 futures-lite = "1.12"
 crossbeam-channel = "0.5"
@@ -40,7 +40,7 @@ futures = "0.3"
 futures-timer = "3.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-naia-server-socket = ">=0.7.4"
+naia-server-socket = "0.8"
 
 [dev-dependencies]
 clap = "2.34.0"

--- a/examples/idle_timeout.rs
+++ b/examples/idle_timeout.rs
@@ -75,7 +75,7 @@ fn startup(mut net: ResMut<NetworkResource>, args: Res<Args>) {
     }
     if !args.is_server {
         info!("Starting client");
-        net.connect(server_address);
+        net.connect(&format!("http://{}", server_address.to_string()));
     }
 }
 

--- a/examples/message_coalescing.rs
+++ b/examples/message_coalescing.rs
@@ -121,7 +121,7 @@ fn startup(mut net: ResMut<NetworkResource>, args: Res<Args>) {
     }
     if !args.is_server {
         info!("Starting client");
-        net.connect(server_address);
+        net.connect(&format!("http://{}", server_address.to_string()));
     }
 }
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -48,7 +48,7 @@ fn startup(mut net: ResMut<NetworkResource>, args: Res<Args>) {
     }
     if !args.is_server {
         info!("Starting client");
-        net.connect(server_address);
+        net.connect(&format!("http://{}", server_address.to_string()));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use bevy::{
 };
 #[cfg(not(target_arch = "wasm32"))]
 use crossbeam_channel::{unbounded, SendError as CrossbeamSendError, Sender};
+use naia_socket_shared::SocketConfig;
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::RwLock;
 use std::{
@@ -18,13 +19,13 @@ use std::{
     sync::{atomic, Arc, Mutex},
 };
 
-use naia_client_socket::ClientSocket;
+use naia_client_socket::Socket as ClientSocket;
 #[cfg(not(target_arch = "wasm32"))]
-use naia_server_socket::ServerSocket;
+use naia_server_socket::Socket as ServerSocket;
 
-pub use naia_client_socket::LinkConditionerConfig;
+pub use naia_socket_shared::LinkConditionerConfig;
 #[cfg(not(target_arch = "wasm32"))]
-pub use naia_server_socket::find_my_ip_address;
+pub use naia_socket_shared::find_my_ip_address;
 
 use turbulence::{
     buffer::BufferPacketPool,
@@ -223,26 +224,29 @@ impl NetworkResource {
         &mut self,
         socket_address: SocketAddr,
         webrtc_listen_address: Option<SocketAddr>,
-        public_webrtc_address: Option<SocketAddr>,
+        public_webrtc_url: Option<url::Url>,
     ) {
+        use naia_server_socket::ServerAddrs;
+
         let mut server_socket = {
             let webrtc_listen_address = webrtc_listen_address.unwrap_or_else(|| {
                 let mut listen_addr = socket_address;
                 listen_addr.set_port(socket_address.port() + 1);
                 listen_addr
             });
-            let public_webrtc_address = public_webrtc_address.unwrap_or(webrtc_listen_address);
-            let socket = futures_lite::future::block_on(ServerSocket::listen(
-                socket_address,
-                webrtc_listen_address,
-                public_webrtc_address,
-            ));
+            let public_webrtc_url = public_webrtc_url.unwrap_or(format!("http://{}", webrtc_listen_address).parse().expect("could not parse WebRTC URL"));
 
-            if let Some(ref conditioner) = self.link_conditioner {
-                socket.with_link_conditioner(conditioner)
-            } else {
-                socket
-            }
+            let mut socket = ServerSocket::new(SocketConfig {
+                link_condition_config: self.link_conditioner.clone(),
+                ..Default::default()
+            });
+            socket.listen(ServerAddrs {
+                session_listen_addr: socket_address,
+                webrtc_listen_addr: webrtc_listen_address,
+                public_webrtc_url,
+            });
+
+            socket
         };
 
         let server_channels = self.server_channels.clone();
@@ -250,9 +254,10 @@ impl NetworkResource {
         let task_pool = self.task_pool.clone();
 
         self.listeners.push(self.task_pool.spawn(async move {
+            let mut receiver = server_socket.packet_receiver();
             loop {
-                match server_socket.receive().await {
-                    Ok(packet) => {
+                match receiver.receive() {
+                    Ok(Some(packet)) => {
                         let address = packet.address();
                         let message = String::from_utf8_lossy(packet.payload());
                         debug!(
@@ -299,7 +304,7 @@ impl NetworkResource {
                                     transport::ServerConnection::new(
                                         task_pool.clone(),
                                         packet_rx,
-                                        server_socket.get_sender(),
+                                        server_socket.packet_sender(),
                                         address,
                                     ),
                                 ));
@@ -313,6 +318,7 @@ impl NetworkResource {
                             }
                         }
                     }
+                    Ok(None) => (),
                     Err(error) => {
                         error!("Server Receive Error: {}", error);
                     }
@@ -321,17 +327,18 @@ impl NetworkResource {
         }));
     }
 
-    pub fn connect(&mut self, socket_address: SocketAddr) {
-        let mut client_socket = {
-            let socket = ClientSocket::connect(socket_address);
-
-            if let Some(ref conditioner) = self.link_conditioner {
-                socket.with_link_conditioner(conditioner)
-            } else {
-                socket
-            }
+    pub fn connect(&mut self, server_session_url: &str) {
+        let client_socket = {
+            let mut socket = ClientSocket::new(SocketConfig {
+                link_condition_config: self.link_conditioner.clone(),
+                ..Default::default()
+            });
+            
+            socket.connect(server_session_url);
+            socket
         };
-        let sender = client_socket.get_sender();
+
+        let sender = client_socket.packet_sender();
 
         self.pending_connections
             .lock()
@@ -367,7 +374,10 @@ impl NetworkResource {
         payload: Packet,
     ) -> Result<(), Box<dyn Error + Sync + Send + 'static>> {
         match self.connections.get_mut(&handle) {
-            Some(connection) => connection.send(payload),
+            Some(connection) => {
+                connection.send(payload);
+                Ok(())
+            }
             None => Err(Box::new(std::io::Error::new(
                 // FIXME: move to enum Error
                 std::io::ErrorKind::NotFound,
@@ -378,7 +388,7 @@ impl NetworkResource {
 
     pub fn broadcast(&mut self, payload: Packet) {
         for (_handle, connection) in self.connections.iter_mut() {
-            connection.send(payload.clone()).unwrap();
+            connection.send(payload.clone());
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,17 +224,16 @@ impl NetworkResource {
         &mut self,
         socket_address: SocketAddr,
         webrtc_listen_address: Option<SocketAddr>,
-        public_webrtc_url: Option<url::Url>,
+        public_webrtc_url: Option<&str>,
     ) {
         use naia_server_socket::ServerAddrs;
 
-        let mut server_socket = {
+        let server_socket = {
             let webrtc_listen_address = webrtc_listen_address.unwrap_or_else(|| {
                 let mut listen_addr = socket_address;
                 listen_addr.set_port(socket_address.port() + 1);
                 listen_addr
             });
-            let public_webrtc_url = public_webrtc_url.unwrap_or(format!("http://{}", webrtc_listen_address).parse().expect("could not parse WebRTC URL"));
 
             let mut socket = ServerSocket::new(SocketConfig {
                 link_condition_config: self.link_conditioner.clone(),
@@ -243,7 +242,7 @@ impl NetworkResource {
             socket.listen(ServerAddrs {
                 session_listen_addr: socket_address,
                 webrtc_listen_addr: webrtc_listen_address,
-                public_webrtc_url,
+                public_webrtc_url: public_webrtc_url.unwrap_or(&format!("http://{}", webrtc_listen_address)).parse().expect("Could not parse public WebRTC URL"),
             });
 
             socket

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,9 @@ use naia_client_socket::Socket as ClientSocket;
 #[cfg(not(target_arch = "wasm32"))]
 use naia_server_socket::Socket as ServerSocket;
 
-pub use naia_socket_shared::LinkConditionerConfig;
 #[cfg(not(target_arch = "wasm32"))]
 pub use naia_socket_shared::find_my_ip_address;
+pub use naia_socket_shared::LinkConditionerConfig;
 
 use turbulence::{
     buffer::BufferPacketPool,
@@ -239,11 +239,11 @@ impl NetworkResource {
                 link_condition_config: self.link_conditioner.clone(),
                 ..Default::default()
             });
-            socket.listen(ServerAddrs {
-                session_listen_addr: socket_address,
-                webrtc_listen_addr: webrtc_listen_address,
-                public_webrtc_url: public_webrtc_url.unwrap_or(&format!("http://{}", webrtc_listen_address)).parse().expect("Could not parse public WebRTC URL"),
-            });
+            socket.listen(ServerAddrs::new(
+                socket_address,
+                webrtc_listen_address,
+                public_webrtc_url.unwrap_or(&format!("http://{}", webrtc_listen_address)),
+            ));
 
             socket
         };
@@ -332,7 +332,7 @@ impl NetworkResource {
                 link_condition_config: self.link_conditioner.clone(),
                 ..Default::default()
             });
-            
+
             socket.connect(server_session_url);
             socket
         };

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -4,7 +4,6 @@ use bevy::{prelude::error, tasks::TaskPool};
 use bytes::Bytes;
 use instant::{Duration, Instant};
 use std::{
-    error::Error,
     net::SocketAddr,
     sync::{Arc, RwLock},
 };
@@ -14,7 +13,7 @@ use naia_client_socket::{
 };
 #[cfg(not(target_arch = "wasm32"))]
 use naia_server_socket::{
-    Packet as ServerPacket, PacketSender as ServerSender, Socket as ServerSocket,
+    Packet as ServerPacket, PacketSender as ServerSender
 };
 
 use turbulence::{
@@ -23,9 +22,6 @@ use turbulence::{
     packet::PacketPool,
     packet_multiplexer::{IncomingMultiplexedPackets, MuxPacket, MuxPacketPool, PacketMultiplexer},
 };
-
-#[cfg(not(target_arch = "wasm32"))]
-use futures_lite::future::block_on;
 
 use futures_lite::StreamExt;
 
@@ -212,7 +208,7 @@ impl Connection for ServerConnection {
         let (channels_rx, mut channels_tx) = multiplexer.start();
         self.channels_rx = Some(channels_rx);
 
-        let mut sender = self.sender.take().unwrap();
+        let sender = self.sender.take().unwrap();
         let client_address = self.client_address;
         let stats = self.stats.clone();
 


### PR DESCRIPTION
My attempt at updating naia-socket to the latest version. The examples work and my personal project works perfectly.

FYI - it is a breaking change to the interface, as the WebRTC address has been replaced with a URL in naia-socket to allow connecting over HTTPS and resolving hostnames. This is a great change, just wanted to make note of the breakage.

Open to modification requests.

Also would fix #50 